### PR TITLE
Ignore case and accept service name as input, closes #11

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "bluebird": "^3.4.0",
-		"hubot-cf-convenience": "latest",
+    "hubot-cf-convenience": "latest",
     "hubot-ibmcloud-cognitive-lib": "latest",
     "hubot-ibmcloud-activity-emitter": "latest",
     "hubot-ibmcloud-utils": "latest",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "bluebird": "^3.4.0",
+		"hubot-cf-convenience": "latest",
     "hubot-ibmcloud-cognitive-lib": "latest",
     "hubot-ibmcloud-activity-emitter": "latest",
     "hubot-ibmcloud-utils": "latest",

--- a/src/lib/estado.js
+++ b/src/lib/estado.js
@@ -106,7 +106,8 @@ function getServiceStatus(domain, service) {
 					var row = $(this);
 					if (row.attr('class') !== 'info') {
 						var cols = $('td', row);
-						if (cols.first().text() === service) {
+						service = service.toLowerCase();
+						if (cols.first().text().toLowerCase() === service) {
 							status = cols.last().text();
 							return false;
 						}

--- a/src/scripts/ibmcloud.status.js
+++ b/src/scripts/ibmcloud.status.js
@@ -278,10 +278,8 @@ module.exports = function(robot) {
 			let message = i18n.__('cognitive.parse.problem.service');
 			robot.emit('ibmcloud.formatter', { response: res, message: message});
 		}
-		console.log('here1');
 		console.log(region);
 		console.log(service);
-		console.log('here2');
 		if (region && service){
 			serviceStatus(res, region, service);
 		}

--- a/src/scripts/ibmcloud.status.js
+++ b/src/scripts/ibmcloud.status.js
@@ -21,6 +21,7 @@ var TAG = path.basename(__filename);
 
 var statusModule = require('../lib/estado');
 var Promise = require('bluebird');
+const cf = require('hubot-cf-convenience');
 const activity = require('hubot-ibmcloud-activity-emitter');
 
 
@@ -294,7 +295,7 @@ module.exports = function(robot) {
 		robot.logger.debug(`${TAG}: ${SERVICE_STATUS_ID} res.message.text=${res.message.text}.`);
 		var regionInfo = regionForInputText(aRegion);
 		var region = regionInfo.domain;
-		var service = aService;
+		var service = cf.getServiceLabel(aService);
 		robot.logger.info(`${TAG}: Asynch call using status module to check on service ${service} in domain ${region}`);
 		statusModule.getServiceStatus(region, service).then(function(status) {
 			var color = status === 'up' ? COLORS.healthy : COLORS.outage;
@@ -360,7 +361,7 @@ module.exports = function(robot) {
 		var regionInfo = regionForInputText(aRegion);
 		var domain = regionInfo.domain;
 		var status = theStatus;
-		var service = aService;
+		var service = cf.getServiceLabel(aService);
 		if (notificationRequests.length < MAX_NB_OF_NOTIFICATIONS) {
 			notificationRequests.push({
 				timestamp: Date.now(),


### PR DESCRIPTION
- As requested in the issue, `service status` now ignores case. i.e. weatherInsights and weatherinsights both work now.
- Use `hubot-cf-convenience` logic to look in the service cache for a valid label when user inputs a service display name. **Note:** this will only work if the user provides Bluemix credentials in their `config/env` file.

i.e. twitterinsights (label) and Insights for Twitter (display name) both work now.

<img width="403" alt="screen shot 2016-08-25 at 10 01 33 am" src="https://cloud.githubusercontent.com/assets/4438261/17974181/0a1097e8-6ab3-11e6-91d9-dcf53fd46d2e.png">
