### PR TITLE
Add ability to get status for and monitor all services in the current space.  Closes #20.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ If you are new to Hubot visit the [getting started](https://hubot.github.com/doc
 - `hubot ibmcloud status space` - Provide status for ibmcloud services in the current space.
 - `hubot ibmcloud status monitor space [ANY|CLEAR]` - Monitor and send notifications when any service in the current space goes [UP|DOWN].
 
+There are two ways to monitor services:
+
+1. Setting a one-time notification using the UP or DOWN status on the monitor service command.  If the status for the service is checked and its value matches the value specified on the command, then a notification message is displayed and the monitoring of that service is stopped.
+2. Setting a persistent notification using the ANY status.  Each time the status of the service transitions from up to down or from down to up, then a notification message is displayed.  The persistent monitoring for the service can be stopped by issuing the monitor command with the CLEAR status.
+
+There is only one way to monitor the services in the current space and that is using the ANY and CLEAR statuses to enable and disable persistent monitoring for all services in the current space.  One-time notification is not supported for spaces.
+
 ## Hubot Adapter Setup
 
 Hubot supports a variety of adapters to connect to popular chat clients.  For more feature rich experiences you can setup the following adapters:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ If you are new to Hubot visit the [getting started](https://hubot.github.com/doc
 - `hubot ibmcloud status help` - Show available ibmcloud status commands.
 - `hubot ibmcloud status region [US South | United Kingdom | Sydney]` - Provide status for ibmcloud services in region.
 - `hubot ibmcloud status service [US South | United Kingdom | Sydney] [SERVICE]` - Provide status for ibmcloud service named [SERVICE] in region.
-- `hubot ibmcloud status monitor [US South | United Kingdom | Sydney] [UP|DOWN][SERVICE]` - Monitor and send notifications when [SERVICE] in region goes [UP|DOWN].
+- `hubot ibmcloud status monitor [US South | United Kingdom | Sydney] [UP|DOWN|ANY|CLEAR][SERVICE]` - Monitor and send notifications when [SERVICE] in region goes [UP|DOWN].
+- `hubot ibmcloud status space` - Provide status for ibmcloud services in the current space.
+- `hubot ibmcloud status monitor space [ANY|CLEAR]` - Monitor and send notifications when any service in the current space goes [UP|DOWN].
 
 ## Hubot Adapter Setup
 

--- a/package.json
+++ b/package.json
@@ -12,13 +12,12 @@
     "slack": "source config/env && hubot -a slack",
     "facebook": "source config/env && hubot -a fb",
     "postinstall": "initDb src/nlc/NLC.json",
-    "test": "mocha --require coffee-script/register --compilers coffee:coffee-script test",
-    "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
+    "test": ". test/.env && mocha --require coffee-script/register --compilers coffee:coffee-script test",
+    "coverage": ". test/.env && istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },
   "author": "ibm-cloud-solutions",
   "license": "Apache-2.0",
   "dependencies": {
-    "bluebird": "^3.4.0",
     "superagent": "^1.8.3",
     "cheerio": "^0.20.0"
   },
@@ -41,11 +40,11 @@
   },
   "peerDependencies": {
     "hubot": "^2.19.0",
-    "hubot-cf-convenience": ">=0.0.13",
-    "hubot-ibmcloud-activity-emitter": ">=0.0.3",
-    "hubot-ibmcloud-cognitive-lib": ">=0.0.40",
-    "hubot-ibmcloud-formatter": ">=0.0.29",
-    "hubot-ibmcloud-utils": ">=0.0.14",
+    "hubot-cf-convenience": ">=0.0.x",
+    "hubot-ibmcloud-activity-emitter": ">=0.0.x",
+    "hubot-ibmcloud-cognitive-lib": ">=0.0.41",
+    "hubot-ibmcloud-formatter": ">=0.0.x",
+    "hubot-ibmcloud-utils": ">=0.0.x",
     "i18n-2": "^0.6.3"
   },
   "engines": {

--- a/src/lib/estado.js
+++ b/src/lib/estado.js
@@ -8,7 +8,6 @@
 
 var request = require('superagent');
 var cheerio = require('cheerio');
-var Promise = require('bluebird');
 var nlcconfig = require('hubot-ibmcloud-cognitive-lib').nlcconfig;
 
 var CACHE_TIMEOUT = Number.parseInt(process.env.CACHE_TIMEOUT, 10) || 60000;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,22 +1,31 @@
 {
 	"estado.error": "Sorry, an error occured while attempting to collect IBM Cloud status information.",
 	"service.in.region": "%s in %s Region",
+	"service.in.space": "%s in %s Space",
 	"service.status": "Service is %s.",
 	"service.monitoring.status": "The status of service %s in region %s is still not %s after %s (current value: %s), Stopping monitor now.",
 	"healthy.region.status": "%s Region Healthy Services",
+	"healthy.space.status": "%s Space Healthy Services",
 	"healthy.services": "%s healthy services.",
 	"unhealthy.region.status": "%s Region Service Outages",
+	"unhealthy.space.status": "%s Space Service Outages",
 	"services.doing.well": "Services doing well",
 	"all.services.up": "All %s services are healthy.",
 	"service.region.status": "%s in %s Region is %s",
 	"monitoring.started": "Service monitoring started",
 	"monitoring.status": "%s in %s with %s status.",
-	"max.registered": "Sorry, too many notifications are already registered.",
+	"monitoring.status.any": "%s in %s with any status change.",
+	"monitoring.stopped": "Service monitoring stopped for %s in %s",
+	"monitoring.space.started": "Service monitoring for any status change in %s space started",
+	"monitoring.space.stopped": "Service monitoring for %s space stopped",
 	"ibmcloud.status.region.help": "Provide status for IBM Cloud services in region.",
 	"ibmcloud.status.service.help": "Provide status for IBM Cloud service named [SERVICE] in region.",
 	"ibmcloud.status.monitor.help": "Monitor and send notifications when [SERVICE] in region goes [UP%sDOWN].",
+	"ibmcloud.status.space.help": "Provide status for IBM Cloud services in the active space.",
+	"ibmcloud.status.monitor.space.help": "Monitor and send notifications when services in the active space go [UP%sDOWN].",
 
 	"cognitive.parse.problem.region": "I'm having problems understanding the IBM Cloud region it should be *US South*, *United Kingdom*, or *Sydney*.",
 	"cognitive.parse.problem.service": "I'm having problems understanding the IBM Cloud service that you want the status on.",
-	"cognitive.parse.problem.status": "I'm having problems understanding the status type you want to be alerted on *up* or *down*. To monitor a service use *ibmcloud status monitor [US South | United Kingdom | Sydney] [UP|DOWN][SERVICE]*"
+	"cognitive.parse.problem.status": "I'm having problems understanding the status type you want to be alerted on *up*, *down*, or *any*. To monitor a service use *ibmcloud status monitor [US South | United Kingdom | Sydney] [UP|DOWN|ANY|CLEAR][SERVICE]*",
+	"cognitive.parse.problem.spacestatus": "I'm having problems understanding the status type you want to be alerted on. To monitor all services in the current space use *ibmcloud status monitor space [ANY|CLEAR]*"
 }

--- a/src/nlc/NLC.json
+++ b/src/nlc/NLC.json
@@ -61,9 +61,12 @@
 			"emittarget": "ibmcloud.service.monitor",
 			"texts": [
 				"I want to monitor the status of the service",
+				"I no longer want to monitor the status of the service",
 				"Notify me when the service health changes",
 				"Alert me when a service goes down",
-				"Tell me when a service comes back up"
+				"Tell me when a service comes back up",
+				"Notify me of any service status changes",
+				"Clear all service status changes"
 			],
 			"parameters" : [
 				{
@@ -83,7 +86,39 @@
 					"name": "status",
 					"title": "status",
 					"type": "keyword",
-					"prompt": "OK. What status do you want to be alerted for *up* or *down*?"
+					"prompt": "OK. What status do you want to be alerted for *up*, *down* or *any* status changes or do you want to *clear* the alert?"
+				}
+			]
+		},
+		{
+			"class": "ibmcloud.space.status",
+			"description": "Show the status of Bluemix services in the current space",
+			"emittarget": "ibmcloud.space.status",
+			"texts": [
+				"Can you provide the status for services in the current space",
+				"Please obtain the status of my services",
+				"health of the services in my space"
+			]
+		},
+		{
+			"class": "ibmcloud.space.monitor",
+			"description": "Monitor the status of Bluemix services in the current space",
+			"emittarget": "ibmcloud.space.monitor",
+			"texts": [
+				"I want to monitor the status of the services in the current space",
+				"I no longer want to monitor the status of the services in the current space",
+				"Notify me when health changes for services in the current space",
+				"Alert me when services in my space go down",
+				"Tell me when a services in my space come back up",
+				"Notify me of any service status changes in the current space",
+				"Clear all service status changes in the current space"
+			],
+			"parameters" : [
+				{
+					"name": "spacestatus",
+					"title": "status",
+					"type": "keyword",
+					"prompt": "OK. What status do you want to be alerted for *any* status changes or *clear* the alerts for the current space?"
 				}
 			]
 		}
@@ -99,7 +134,11 @@
 		},
 		{
 			"name": "status",
-			"values": ["up", "down"]
+			"values": ["up", "down", "any", "clear"]
+		},
+		{
+			"name": "spacestatus",
+			"values": ["any", "clear"]
 		}
 	]
 }

--- a/src/scripts/ibmcloud.status.js
+++ b/src/scripts/ibmcloud.status.js
@@ -20,7 +20,6 @@ var path = require('path');
 var TAG = path.basename(__filename);
 
 var statusModule = require('../lib/estado');
-var Promise = require('bluebird');
 const cf = require('hubot-cf-convenience');
 const activity = require('hubot-ibmcloud-activity-emitter');
 const entities = require('../lib/status.entities');
@@ -48,8 +47,12 @@ const REGION_STATUS_RE = /ibmcloud\s+status\s+region\s+(US South|United Kingdom|
 const REGION_STATUS_ID = 'ibmcloud.region.status';
 const SERVICE_STATUS_RE = /ibmcloud\s+status\s+service\s+(US South|United Kingdom|Sydney)\s+(.*)/i;
 const SERVICE_STATUS_ID = 'ibmcloud.service.status';
-const SERVICE_MONITOR_RE = /ibmcloud\s+status\s+monitor\s+(US South|United Kingdom|Sydney)\s+(up|down)\s+(.*)/i;
+const SERVICE_MONITOR_RE = /ibmcloud\s+status\s+monitor\s+(US South|United Kingdom|Sydney)\s+(up|down|any|clear)\s+(.*)/i;
 const SERVICE_MONITOR_ID = 'ibmcloud.service.monitor';
+const SPACE_STATUS_RE = /ibmcloud\s+status\s+space/i;
+const SPACE_STATUS_ID = 'ibmcloud.space.status';
+const SPACE_MONITOR_RE = /ibmcloud\s+status\s+monitor\s+space\s+(any|clear)/i;
+const SPACE_MONITOR_ID = 'ibmcloud.space.monitor';
 
 module.exports = function(robot) {
 	var COLORS = {
@@ -62,114 +65,290 @@ module.exports = function(robot) {
 		label: process.env.NOTIFICATION_TIMEOUT_LABEL || '8 hours', // eslint-disable-line no-irregular-whitespace
 		value: Number.parseInt(process.env.NOTIFICATION_TIMEOUT_VALUE, 10) || 8 * 60 * 60000
 	};
-	var MAX_NB_OF_NOTIFICATIONS = Number.parseInt(process.env.MAX_NB_OF_NOTIFICATIONS, 10) || 20;
 
 	(function() {
 		var logMessage = [
 			'Using the following notifications settings:',
 			'- Notification period: ' + NOTIFICATION_PERIOD_IN_MS + ' ms',
 			'- Notification timeout: ' + NOTIFICATION_TIMEOUT.value + ' ms',
-			'- Label for notification timeout: ' + NOTIFICATION_TIMEOUT.label,
-			'- Max number of notifications: ' + MAX_NB_OF_NOTIFICATIONS
+			'- Label for notification timeout: ' + NOTIFICATION_TIMEOUT.label
 		];
 		robot.logger.info(TAG + ': ' + logMessage.join('\n'));
 	})();
 
-	var notificationRequests = [];
+	// Domain contants
+	const DOMAIN_USSOUTH = 'ng';
+	const DOMAIN_UK = 'eu-gb';
+	const DOMAIN_SYDNEY = 'au-syd';
+	const DOMAINS = [
+		DOMAIN_USSOUTH,
+		DOMAIN_UK,
+		DOMAIN_SYDNEY
+	];
 
-	// Register entity handling functions
-	entities.registerEntityFunctions();
+	// Region/domain info
+	var REGION_INFO = {};
+	DOMAINS.forEach(function(domain) {
+		REGION_INFO[domain] = {
+			domain: domain,
+			url: 'http://estado.' + domain + '.bluemix.net'
+		};
+	});
+	REGION_INFO[DOMAIN_USSOUTH].region = 'US South';
+	REGION_INFO[DOMAIN_UK].region = 'United Kingdom';
+	REGION_INFO[DOMAIN_SYDNEY].region = 'Sydney';
 
-	setInterval(function() {
-		if (notificationRequests.length) {
-			robot.logger.info(`${TAG}: checking service status for ${notificationRequests.length} notification requests`);
+	// Notification request definitions
+	var notificationRequestMap = {
+	};
+	DOMAINS.forEach(function(domain) {
+		notificationRequestMap[domain] = {
+			monitoredServices: [],  // Each item in array is an object with three fields: service, monitorStatus, and res
+			monitoredSpace: [],  // Each item in array is an object with one field: res
+			prevStatus: null,
+			currStatus: null
+		};
+	});
 
-			var promises = [];
-			notificationRequests.forEach(function(request) {
-				robot.logger.info(`${TAG}: Promise added to check if service ${request.service} is ${request.status} on domain ${request.domain}`);
-				promises.push(statusModule.getServiceStatus(request.domain, request.service).then(function(lastStatus) {
-					if (request.status === lastStatus) {
-						var color = lastStatus === 'up' ? COLORS.healthy : COLORS.outage;
-						robot.emit('ibmcloud.formatter', {
-							response: request.res,
-							attachments: [{
-								title: i18n.__('service.in.region', request.service, request.region),
-								title_link: request.regionUrl,
-								text: i18n.__('service.status', lastStatus.toUpperCase()),
-								color: color
-							}]
-						});
-						activity.emitBotActivity(robot, request.res, { activity_id: 'activity.service.monitor'});
-						return false;
-					}
-					else if (Date.now() - request.timestamp > NOTIFICATION_TIMEOUT.value) {
-						robot.emit('ibmcloud.formatter', {
-							response: request.res,
-							attachments: [{
-								title: i18n.__('service.in.region', request.service, request.region),
-								title_link: request.regionUrl,
-								text: i18n.__('service.monitoring.status', request.service, request.region, request.status.toUpperCase(), NOTIFICATION_TIMEOUT.label, lastStatus.toUpperCase()),
-								color: color
-							}]
-						});
-						activity.emitBotActivity(robot, request.res, { activity_id: 'activity.service.monitor'});
-						return false;
-					}
-					else {
-						// Keep the notification in the array
-						return true;
-					}
-				}, function(err) {
-					robot.logger.error(`${TAG}: An error occurred.`);
-					robot.logger.error(err);
-					return true;
-				}).reflect());
-			});
-			robot.logger.info(`${TAG}: Async calls (Promise.all) for service checks (promises).`);
-			Promise.all(promises).then(function(values) {
-				notificationRequests = notificationRequests.filter(function(entry, index) {
-					var inspection = values[index];
-					if (inspection.isFulfilled()) {
-						var value = inspection.value();
-						if (!value) {
-							// delete the bot res object from the notification
-							delete entry.res;
-						}
-						return value;
-					}
-					else {
-						return true;
-					}
-				});
-				robot.logger.info(`${TAG}: notificationRequests length is now ${notificationRequests.length}`);
-			});
-		}
-	}, NOTIFICATION_PERIOD_IN_MS);
-
-	function regionForInputText(text) {
+	function regionInfoForDomain(domain) {
+		return REGION_INFO[domain];
+	}
+	function regionInfoForRegion(text) {
 		var lowercaseText = text.toLowerCase();
-		switch (lowercaseText) {
-		case 'us south':
-			return {
-				domain: 'ng',
-				url: 'http://estado.ng.bluemix.net'
-			};
-		case 'united kingdom':
-			return {
-				domain: 'eu-gb',
-				url: 'http://estado.eu-gb.bluemix.net'
-			};
-		case 'sydney':
-			return {
-				domain: 'au-syd',
-				url: 'http://estado.au-syd.bluemix.net'
-			};
-		default:
-			{
-				return undefined;
+		let domains = Object.keys(REGION_INFO);
+		for (let i = 0; i < domains.length; i++) {
+			let ri = REGION_INFO[domains[i]];
+			if (ri.region.toLowerCase() === lowercaseText) {
+				return ri;
 			}
 		}
+		return undefined;
 	}
+	function regionInfoForEnv() {
+		let bluemixApi = process.env.HUBOT_BLUEMIX_API;
+		let domains = Object.keys(REGION_INFO);
+		for (let i = 0; i < domains.length; i++) {
+			let ri = REGION_INFO[domains[i]];
+			if (bluemixApi.indexOf('.' + ri.domain + '.') >= 0) {
+				return ri;
+			}
+		}
+		return undefined;
+	}
+
+	setInterval(function() {
+
+		// Process each of the notification requests for each of the regions(domains)
+		Object.keys(notificationRequestMap).forEach(function(domain) {
+
+			let notificationRequest = notificationRequestMap[domain];
+			let regionInfo = regionInfoForDomain(domain);
+
+			// See if any monitoring requests have been made for this domain
+			if (notificationRequest.monitoredServices.length > 0 || notificationRequest.monitoredSpace.length > 0) {
+				notificationRequest.prevStatus = notificationRequest.currStatus;
+				robot.logger.info(`${TAG}: checking service status for services in domain ${domain}`);
+
+				// Get current status of all services in this domain
+				statusModule.getStatus(domain).then(function(resp) {
+					notificationRequest.currStatus = resp;
+
+					// Check status of all explicitly monitored services.
+					// If the status being monitored is down and the service is down,
+					// then send message to the user and remove the monitoring item
+					// (this is a one-time alert).
+					// If the status being monitored is up and the service is up,
+					// then send message to the user and remove the monitoring item
+					// (this too is a one-time alert).
+					// If the status being monitored is any and the service has
+					// transitioned to up or down, then send message to the user
+					// (do not remove the monitoring item because this is a persistent alert).
+					// Process services in reverse order so that they can be easily removed
+					// from the array if the expected status is found.
+					for (let i = notificationRequest.monitoredServices.length - 1; i >= 0; i--) {
+						let monitoredService = notificationRequest.monitoredServices[i];
+						let prevStatus = 'unknown';
+						if (notificationRequest.prevStatus != null) {
+							prevStatus = (notificationRequest.prevStatus.ok.indexOf(monitoredService.service) >= 0 ? 'up' : (notificationRequest.prevStatus.ko.indexOf(monitoredService.service) >= 0 ? 'down' : 'unknown'));
+						}
+						let currStatus = (notificationRequest.currStatus.ok.indexOf(monitoredService.service) >= 0 ? 'up' : (notificationRequest.currStatus.ko.indexOf(monitoredService.service) >= 0 ? 'down' : 'unknown'));
+						let monitoredServiceRemoved = false;
+
+						// If current status for service is down, then see if we need to send alert msg.
+						if (currStatus === 'down') {
+
+							// If the status being monitored is down or the status being monitored
+							// is any and the previous status was up, then send message to the user.
+							if ((monitoredService.monitorStatus === 'down') ||
+								(monitoredService.monitorStatus === 'any' && prevStatus === 'up')) {
+
+								// Send message to the user
+								robot.emit('ibmcloud.formatter', {
+									response: monitoredService.res,
+									attachments: [{
+										title: i18n.__('service.in.region', monitoredService.service, regionInfo.region),
+										title_link: regionInfo.url,
+										text: i18n.__('service.status', 'DOWN'),
+										color: COLORS.outage
+									}]
+								});
+								activity.emitBotActivity(robot, monitoredService.res, { activity_id: 'activity.service.monitor'});
+
+								// If the status being monitored is not 'any' then remove the service from
+								// the list since this is a one-time alert.
+								if (monitoredService.monitorStatus !== 'any') {
+									notificationRequest.monitoredServices.splice(i, 1);
+									monitoredServiceRemoved = true;
+								}
+
+							}
+
+						}
+
+						// If current status for service is up, then see if we need to send alert msg.
+						else if (currStatus === 'up') {
+
+							// If the status being monitored is up or the status being monitored
+							// is any and the previous status was down, then send message to the user.
+							if ((monitoredService.monitorStatus === 'up') ||
+								(monitoredService.monitorStatus === 'any' && prevStatus === 'down')) {
+
+								// Send message to the user
+								robot.emit('ibmcloud.formatter', {
+									response: monitoredService.res,
+									attachments: [{
+										title: i18n.__('service.in.region', monitoredService.service, regionInfo.region),
+										title_link: regionInfo.url,
+										text: i18n.__('service.status', 'UP'),
+										color: COLORS.healthy
+									}]
+								});
+								activity.emitBotActivity(robot, monitoredService.res, { activity_id: 'activity.service.monitor'});
+
+								// If the status being monitored is not 'any' then remove the service from
+								// the list since this is a one-time alert.
+								if (monitoredService.monitorStatus !== 'any') {
+									notificationRequest.monitoredServices.splice(i, 1);
+									monitoredServiceRemoved = true;
+								}
+
+							}
+
+						}
+
+						// If the monitorStatus is not 'any' and the monitor timeout is exceed then
+						// remove the service from the list.
+						if (monitoredServiceRemoved === false && monitoredService.monitorStatus !== 'any' &&
+							(Date.now() - monitoredService.timestamp > NOTIFICATION_TIMEOUT.value)) {
+
+							// Send message to user
+							robot.emit('ibmcloud.formatter', {
+								response: monitoredService.res,
+								attachments: [{
+									title: i18n.__('service.in.region', monitoredService.service, regionInfo.region),
+									title_link: regionInfo.url,
+									text: i18n.__('service.monitoring.status', monitoredService.service, regionInfo.region, monitoredService.monitorStatus.toUpperCase(), NOTIFICATION_TIMEOUT.label, prevStatus.toUpperCase()),
+									color: undefined
+								}]
+							});
+							activity.emitBotActivity(robot, monitoredService.res, { activity_id: 'activity.service.monitor'});
+
+							// Remove the service from the list since it has timed out
+							notificationRequest.monitoredServices.splice(i, 1);
+
+						}
+					}
+
+					// If the active space is being monitored and it is in this domain,
+					// then determine if any services in the active space have changed status.
+					// If so, send message to the user(s).  This is a persistent alert so nothing
+					// is removed from the notification request.
+					if (notificationRequest.monitoredSpace.length > 0) {
+
+						// Go through each requesting user and obtain their current space
+						notificationRequest.monitoredSpace.forEach(function(monitoredSpace) {
+							let activeSpace = cf.activeSpace(robot, monitoredSpace.res);
+
+							// Get all services in their current space
+							getServicesInSpace(activeSpace.guid).then(function(services) {
+
+								services.forEach(function(service) {
+									let prevStatus = 'unknown';
+									if (notificationRequest.prevStatus != null) {
+										prevStatus = (notificationRequest.prevStatus.ok.indexOf(service) >= 0 ? 'up' : (notificationRequest.prevStatus.ko.indexOf(service) >= 0 ? 'down' : 'unknown'));
+									}
+									let currStatus = (notificationRequest.currStatus.ok.indexOf(service) >= 0 ? 'up' : (notificationRequest.currStatus.ko.indexOf(service) >= 0 ? 'down' : 'unknown'));
+
+									// If the current status is down
+									if (currStatus === 'down') {
+
+										// If the previous status was up, send message to requesting users
+										if (prevStatus === 'up') {
+
+											// Send message to the user
+											robot.emit('ibmcloud.formatter', {
+												response: monitoredSpace.res,
+												attachments: [{
+													title: i18n.__('service.in.space', service, activeSpace.name),
+													title_link: regionInfo.url,
+													text: i18n.__('service.status', 'DOWN'),
+													color: COLORS.outage
+												}]
+											});
+											activity.emitBotActivity(robot, monitoredSpace.res, { activity_id: 'activity.service.monitor'});
+
+										}
+
+									}
+
+									// If the current status is up
+									else if (currStatus === 'up') {
+
+										// If the previous status was down, send message to requesting users
+										if (prevStatus === 'down') {
+
+											// Send message to the user
+											robot.emit('ibmcloud.formatter', {
+												response: monitoredSpace.res,
+												attachments: [{
+													title: i18n.__('service.in.space', service, activeSpace.name),
+													title_link: regionInfo.url,
+													text: i18n.__('service.status', 'UP'),
+													color: COLORS.healthy
+												}]
+											});
+											activity.emitBotActivity(robot, monitoredSpace.res, { activity_id: 'activity.service.monitor'});
+
+										}
+
+									}
+
+								});
+
+							}).catch(function(err) {
+								robot.logger.error(`${TAG}: An error occurred.`);
+								robot.logger.error(err);
+							});
+
+						});
+
+					}
+
+				}).catch(function(err) {
+					robot.logger.error(`${TAG}: An error occurred.`);
+					robot.logger.error(err);
+				});
+
+			}
+
+			// If we didn't get the status this time through, then wipe it out
+			else {
+				notificationRequest.prevStatus = null;
+				notificationRequest.currStatus = null;
+			}
+
+		});
+	}, NOTIFICATION_PERIOD_IN_MS);
 
 	var reportIssue = function(res, message) {
 		robot.logger.error(`${TAG}: An error occurred.`);
@@ -178,27 +357,8 @@ module.exports = function(robot) {
 		robot.emit('ibmcloud.formatter', { response: res, message: msg});
 	};
 
-	robot.on(CLOUD_STATUS_HELP_ID, (res) => {
-		robot.logger.debug(`${TAG}: ${CLOUD_STATUS_HELP_ID} Natural Language match.`);
-		help(res);
-	});
-	robot.respond(CLOUD_STATUS_HELP_RE, {id: CLOUD_STATUS_HELP_ID}, function(res) {
-		robot.logger.debug(`${TAG}: ${CLOUD_STATUS_HELP_ID} Reg Ex match.`);
-		help(res);
-	});
-	function help(res) {
-		robot.logger.info(`${TAG}: ${CLOUD_STATUS_HELP_ID} Listing ibmcloud status help...`);
-		// hubot ibmcloud status region [US South | United Kingdom | Sydney] - Provide status for ibmcloud services in region.
-		// hubot ibmcloud status service [US South | United Kingdom | Sydney] [SERVICE] - Provide status for ibmcloud service named [SERVICE] in region.
-		// hubot ibmcloud status monitor [US South | United Kingdom | Sydney] [UP|DOWN][SERVICE] - Monitor and send notifications when [SERVICE] in region goes [UP|DOWN].
-		let regionHelp = i18n.__('ibmcloud.status.region.help');
-		let serviceHelp = i18n.__('ibmcloud.status.service.help');
-		let monitorHelp = i18n.__('ibmcloud.status.monitor.help', '|');
-		let help = `${robot.name} ibmcloud status region [US South | United Kingdom | Sydney] - ${regionHelp}\n`;
-		help += `${robot.name} ibmcloud status service [US South | United Kingdom | Sydney] [SERVICE] - ${serviceHelp}\n`;
-		help += `${robot.name} ibmcloud status monitor [US South | United Kingdom | Sydney] [UP|DOWN][SERVICE] - ${monitorHelp}\n`;
-		robot.emit('ibmcloud.formatter', { response: res, message: help});
-	};
+	// Register entity handling functions
+	entities.registerEntityFunctions();
 
 	robot.on(REGION_STATUS_ID, (res, parameters) => {
 		robot.logger.debug(`${TAG}: ${REGION_STATUS_ID} Natural Language match.`);
@@ -218,7 +378,7 @@ module.exports = function(robot) {
 	});
 	function regionStatus(res, aRegion) {
 		robot.logger.debug(`${TAG}: ${REGION_STATUS_ID} res.message.text=${res.message.text}.`);
-		var regionInfo = regionForInputText(aRegion);
+		var regionInfo = regionInfoForRegion(aRegion);
 		var region = regionInfo.domain;
 		robot.logger.info(`${TAG}: Asynch call using status module to check on domain ${region}`);
 		statusModule.getStatus(region).then(function(resp) {
@@ -283,8 +443,6 @@ module.exports = function(robot) {
 			let message = i18n.__('cognitive.parse.problem.service');
 			robot.emit('ibmcloud.formatter', { response: res, message: message});
 		}
-		console.log(region);
-		console.log(service);
 		if (region && service){
 			serviceStatus(res, region, service);
 		}
@@ -297,7 +455,7 @@ module.exports = function(robot) {
 	});
 	function serviceStatus(res, aRegion, aService) {
 		robot.logger.debug(`${TAG}: ${SERVICE_STATUS_ID} res.message.text=${res.message.text}.`);
-		var regionInfo = regionForInputText(aRegion);
+		var regionInfo = regionInfoForRegion(aRegion);
 		var region = regionInfo.domain;
 		var service = cf.getServiceLabel(aService);
 		robot.logger.info(`${TAG}: Asynch call using status module to check on service ${service} in domain ${region}`);
@@ -357,44 +515,299 @@ module.exports = function(robot) {
 		robot.logger.debug(`${TAG}: ${SERVICE_STATUS_ID} Reg Ex match.`);
 		const region = res.match[1];
 		const service = res.match[3];
-		const status = res.match[2].toLowerCase();
+		const status = res.match[2];
 		serviceMonitor(res, region, service, status);
 	});
 	function serviceMonitor(res, aRegion, aService, theStatus) {
 		robot.logger.debug(`${TAG}: ${SERVICE_MONITOR_ID} res.message.text=${res.message.text}.`);
-		var regionInfo = regionForInputText(aRegion);
+		var regionInfo = regionInfoForRegion(aRegion);
 		var domain = regionInfo.domain;
-		var status = theStatus;
+		var status = theStatus.toLowerCase();
 		var service = cf.getServiceLabel(aService);
-		if (notificationRequests.length < MAX_NB_OF_NOTIFICATIONS) {
-			notificationRequests.push({
-				timestamp: Date.now(),
-				service: service,
-				domain: domain,
-				region: aRegion,
-				regionUrl: regionInfo.url,
-				status: status,
-				res: res
-			});
+
+		// See if this user is currently monitoring this service in this domain
+		let matchIndex = -1;
+		let notificationRequest = notificationRequestMap[domain];
+		for (let i = 0; i < notificationRequest.monitoredServices.length; i++) {
+			let monitoredService = notificationRequest.monitoredServices[i];
+			if (service === monitoredService.service && res.message.user.id === monitoredService.res.message.user.id) {
+				matchIndex = i;
+				break;
+			}
+		}
+
+		// If monitoring a service
+		if (status === 'up' || status === 'down' || status === 'any') {
+
+			// If this user is not currently monitoring this service, then add an
+			// item to the notification request.
+			if (matchIndex < 0) {
+				notificationRequest.monitoredServices.push({
+					service: service,
+					monitorStatus: status,
+					res: res,
+					timestamp: Date.now()
+				});
+			}
+
+			// If the user is currently monitoring this service, then update the item
+			// in the notification request.
+			else {
+				notificationRequest.monitoredServices[matchIndex] = {
+					service: service,
+					monitorStatus: status,
+					res: res
+				};
+			}
+
+			// Notify user that service is now being monitored
+			let theText = (status === 'any'
+				? i18n.__('monitoring.status.any', service, aRegion)
+				: i18n.__('monitoring.status', service, aRegion, status.toUpperCase()));
 			// Emit the app status as an attachment
 			robot.emit('ibmcloud.formatter', {
 				response: res,
 				attachments: [{
 					title: i18n.__('monitoring.started'),
-					text: i18n.__('monitoring.status', service, aRegion, status.toUpperCase()),
+					text: theText,
 					color: COLORS.healthy
 				}]
 			});
+
 		}
+
+		// If clearing the monitoring of a service
 		else {
+
+			// If service was being monitored by this user, then remove it
+			if (matchIndex >= 0) {
+				notificationRequest.monitoredServices.splice(matchIndex, 1);
+			}
+
+			// Notify user that service is no longer being monitored
 			robot.emit('ibmcloud.formatter', {
 				response: res,
 				attachments: [{
-					title: i18n.__('max.registered'),
-					color: COLORS.outage
+					title: i18n.__('monitoring.stopped', service, aRegion),
+					color: COLORS.healthy
 				}]
 			});
+
 		}
+
+	};
+
+	robot.on(SPACE_STATUS_ID, (res, parameters) => {
+		robot.logger.debug(`${TAG}: ${SPACE_STATUS_ID} Natural Language match.`);
+		spaceStatus(res);
+	});
+	robot.respond(SPACE_STATUS_RE, {id: SPACE_STATUS_ID}, function(res) {
+		robot.logger.debug(`${TAG}: ${SPACE_STATUS_ID} Reg Ex match.`);
+		spaceStatus(res);
+	});
+	function getServicesInSpace(activeSpaceGuid) {
+		return new Promise(function(resolve, reject) {
+			cf.Spaces.getSummary(activeSpaceGuid).then(function(result) {
+				var services = [];
+				result.services.forEach(function(service) {
+					if (service.service_plan) {
+						services.push(service.service_plan.service.label + ' [' + service.service_plan.name + ']');
+					}
+				});
+				resolve(services);
+			}).catch(function(err) {
+				reject(err);
+			});
+		});
+	}
+	function getStatusForServicesInSpace(activeSpaceGuid, domain) {
+		return new Promise(function(resolve, reject) {
+			getServicesInSpace(activeSpaceGuid).then(function(services) {
+				statusModule.getStatus(domain).then(function(resp) {
+					var newresp = {
+						ok: [],
+						ko: [],
+						unknown: []
+					};
+					services.forEach(function(service) {
+						if (resp.ok.indexOf(service) >= 0) {
+							if (newresp.ok.indexOf(service) < 0) {
+								newresp.ok.push(service);
+							}
+						}
+						else if (resp.ko.indexOf(service) >= 0) {
+							if (newresp.ko.indexOf(service) < 0) {
+								newresp.ko.push(service);
+							}
+						}
+						else {
+							if (newresp.unknown.indexOf(service) < 0) {
+								newresp.unknown.push(service);
+							}
+							robot.logger.debug(`${TAG}: Service ${service} not found in list of estado services.`);
+						}
+					});
+					resolve(newresp);
+				}).catch(function(err) {
+					reject(err);
+				});
+			}).catch(function(err) {
+				reject(err);
+			});
+		});
+	};
+	function spaceStatus(res) {
+		robot.logger.debug(`${TAG}: ${REGION_STATUS_ID} res.message.text=${res.message.text}.`);
+		let activeSpace = cf.activeSpace(robot, res);
+		let regionInfo = regionInfoForEnv();
+		getStatusForServicesInSpace(activeSpace.guid, regionInfo.domain).then(function(resp) {
+			var attachments = [];
+			if (resp.ko.length > 0) {
+				attachments.push({
+					title: i18n.__('healthy.space.status', activeSpace.name),
+					title_link: regionInfo.url,
+					color: COLORS.healthy || '#555',
+					text: i18n.__('healthy.services', resp.ok.length + resp.unknown.length + '')
+				});
+
+				attachments.push({
+					title: i18n.__('unhealthy.space.status', activeSpace.name),
+					title_link: regionInfo.url,
+					color: COLORS.outage || '#555',
+					text: '- ' + resp.ko.join('\n- ')
+				});
+
+			}
+			else {
+				attachments.push({
+					title: i18n.__('healthy.space.status', activeSpace.name),
+					title_link: regionInfo.url,
+					color: COLORS.healthy || '#555',
+					fields: [{
+						title: i18n.__('services.doing.well'),
+						value: i18n.__('all.services.up', resp.ok.length + resp.unknown.length + '')
+					}]
+				});
+			}
+
+			// Emit the app status as an attachment
+			robot.emit('ibmcloud.formatter', {
+				response: res,
+				attachments: attachments
+			});
+			activity.emitBotActivity(robot, res, { activity_id: 'activity.space.status'});
+		}).catch(function(err) {
+			reportIssue(res, err);
+		});
+	};
+
+	robot.on(SPACE_MONITOR_ID, (res, parameters) => {
+		robot.logger.debug(`${TAG}: ${SPACE_MONITOR_ID} Natural Language match.`);
+		let spacestatus;
+		if (parameters && parameters.spacestatus) {
+			spacestatus = parameters.spacestatus;
+		}
+		else {
+			robot.logger.error(`${TAG}: Error extracting Status from text=[${res.message.text}].`);
+			let message = i18n.__('cognitive.parse.problem.spacestatus');
+			robot.emit('ibmcloud.formatter', { response: res, message: message});
+		}
+		if (spacestatus) {
+			spaceMonitor(res, spacestatus);
+		}
+	});
+	robot.respond(SPACE_MONITOR_RE, {id: SPACE_MONITOR_ID}, function(res) {
+		robot.logger.debug(`${TAG}: ${SPACE_MONITOR_ID} Reg Ex match.`);
+		const spacestatus = res.match[1];
+		spaceMonitor(res, spacestatus);
+	});
+	function spaceMonitor(res, spacestatus) {
+		robot.logger.debug(`${TAG}: ${REGION_STATUS_ID} res.message.text=${res.message.text}.`);
+		let activeSpace = cf.activeSpace(robot, res);
+		let regionInfo = regionInfoForEnv();
+		let status = spacestatus.toLowerCase();
+
+		// See if this user is currently monitoring the current space
+		let matchIndex = -1;
+		let notificationRequest = notificationRequestMap[regionInfo.domain];
+		for (let i = 0; i < notificationRequest.monitoredSpace.length; i++) {
+			let monRes = notificationRequest.monitoredSpace[i].res;
+			if (monRes.message.user.id === res.message.user.id) {
+				matchIndex = i;
+				break;
+			}
+		}
+
+		// If monitoring the current space
+		if (status === 'any') {
+
+			// If the current space is not currently being monitored by this user, add it
+			if (matchIndex < 0) {
+				notificationRequest.monitoredSpace.push({
+					res: res
+				});
+			}
+
+			// If the current space is currently being monitored by this user, update it
+			else {
+				notificationRequest.monitoredSpace[matchIndex] = {
+					res: res
+				};
+			}
+
+			// Notify user that current space is now being monitored
+			robot.emit('ibmcloud.formatter', {
+				response: res,
+				attachments: [{
+					title: i18n.__('monitoring.space.started', activeSpace.name),
+					color: COLORS.healthy
+				}]
+			});
+
+		}
+
+		// If clearing the monitoring of the current space
+		else {
+
+			// If current space was being monitored by this user, then remove it
+			if (matchIndex >= 0) {
+				notificationRequest.monitoredSpace.splice(matchIndex, 1);
+			}
+
+			// Notify user that service is no longer being monitored
+			robot.emit('ibmcloud.formatter', {
+				response: res,
+				attachments: [{
+					title: i18n.__('monitoring.space.stopped', activeSpace.name),
+					color: COLORS.healthy
+				}]
+			});
+
+		}
+
+	};
+
+	robot.on(CLOUD_STATUS_HELP_ID, (res) => {
+		robot.logger.debug(`${TAG}: ${CLOUD_STATUS_HELP_ID} Natural Language match.`);
+		help(res);
+	});
+	robot.respond(CLOUD_STATUS_HELP_RE, {id: CLOUD_STATUS_HELP_ID}, function(res) {
+		robot.logger.debug(`${TAG}: ${CLOUD_STATUS_HELP_ID} Reg Ex match.`);
+		help(res);
+	});
+	function help(res) {
+		robot.logger.info(`${TAG}: ${CLOUD_STATUS_HELP_ID} Listing ibmcloud status help...`);
+		let regionHelp = i18n.__('ibmcloud.status.region.help');
+		let serviceHelp = i18n.__('ibmcloud.status.service.help');
+		let monitorHelp = i18n.__('ibmcloud.status.monitor.help', '|');
+		let spaceHelp = i18n.__('ibmcloud.status.space.help');
+		let monitorSpaceHelp = i18n.__('ibmcloud.status.monitor.space.help', '|');
+		let help = `${robot.name} ibmcloud status region [US South | United Kingdom | Sydney] - ${regionHelp}\n`;
+		help += `${robot.name} ibmcloud status service [US South | United Kingdom | Sydney] [SERVICE] - ${serviceHelp}\n`;
+		help += `${robot.name} ibmcloud status monitor [US South | United Kingdom | Sydney] [UP|DOWN|ANY|CLEAR][SERVICE] - ${monitorHelp}\n`;
+		help += `${robot.name} ibmcloud status space - ${spaceHelp}\n`;
+		help += `${robot.name} ibmcloud status monitor space [ANY|CLEAR] - ${monitorSpaceHelp}\n`;
+		robot.emit('ibmcloud.formatter', { response: res, message: help});
 	};
 
 };

--- a/test/.env
+++ b/test/.env
@@ -1,0 +1,9 @@
+export npm_config_test=true
+export HUBOT_BLUEMIX_API=http://my.ng.test
+export HUBOT_BLUEMIX_USER=testUser
+export HUBOT_BLUEMIX_PASSWORD=secret
+export HUBOT_BLUEMIX_ORG=testOrg
+export HUBOT_BLUEMIX_SPACE=testSpace
+export NOTIFICATION_PERIOD_IN_MS=1000
+export NOTIFICATION_TIMEOUT_VALUE=2000
+export NOTIFICATION_TIMEOUT_LABEL="2 seconds"

--- a/test/ibmcloud.status.cognitive.test.js
+++ b/test/ibmcloud.status.cognitive.test.js
@@ -5,6 +5,24 @@ var path = require('path');
 var Helper = require('hubot-test-helper');
 var expect = require('chai').expect;
 var nock = require('nock');
+const mockUtils = require('./mock.utils.cf.js');
+
+
+// --------------------------------------------------------------
+// i18n (internationalization)
+// It will read from a peer messages.json file.  Later, these
+// messages can be referenced throughout the module.
+// --------------------------------------------------------------
+var i18n = new (require('i18n-2'))({
+	locales: ['en'],
+	extension: '.json',
+	directory: __dirname + '/../src/locales',
+	defaultLocale: 'en',
+	// Prevent messages file from being overwritten in error conditions (like poor JSON).
+	updateFiles: false
+});
+// At some point we need to toggle this setting based on some user input.
+i18n.setLocale('en');
 
 // No cache for the tests
 process.env.CACHE_TIMEOUT = '-1';
@@ -32,6 +50,14 @@ var helper = new Helper(path.join(__dirname, '../src/scripts/ibmcloud.status.js'
 describe('Test cloud status via Natural Language', function() {
 
 	var room;
+	let cf;
+
+	before(function() {
+		mockUtils.setupMockery();
+		// initialize cf, hubot-test-helper doesn't test Middleware
+		cf = require('hubot-cf-convenience');
+		return cf.promise.then();
+	});
 
 	beforeEach(function() {
 		room = helper.createRoom();
@@ -67,12 +93,12 @@ describe('Test cloud status via Natural Language', function() {
 
 		it('returns status for region US South', function(done) {
 			testRegionStatus('US South', [{
-				title: 'US South Region Healthy Services',
+				title: i18n.__('healthy.region.status', 'US South'),
 				title_link: 'http://estado.ng.bluemix.net',
 				color: UP_COLOR,
-				text: '295 healthy services.'
+				text: i18n.__('healthy.services', 295 + '')
 			}, {
-				title: 'US South Region Service Outages',
+				title: i18n.__('unhealthy.region.status', 'US South'),
 				title_link: 'http://estado.ng.bluemix.net',
 				color: DOWN_COLOR,
 				text: '- otc-pipeline-ui\n- messageconnect [experimental]\n- MobileApplicationContentManager [Basic]'
@@ -81,12 +107,12 @@ describe('Test cloud status via Natural Language', function() {
 
 		it('returns status for region United Kingdom', function(done) {
 			testRegionStatus('United Kingdom', [{
-				title: 'United Kingdom Region Healthy Services',
+				title: i18n.__('healthy.region.status', 'United Kingdom'),
 				title_link: 'http://estado.eu-gb.bluemix.net',
 				color: UP_COLOR,
-				text: '236 healthy services.'
+				text: i18n.__('healthy.services', 236 + '')
 			}, {
-				title: 'United Kingdom Region Service Outages',
+				title: i18n.__('unhealthy.region.status', 'United Kingdom'),
 				title_link: 'http://estado.eu-gb.bluemix.net',
 				color: DOWN_COLOR,
 				text: '- MobileApplicationContentManager [Basic]'
@@ -95,16 +121,26 @@ describe('Test cloud status via Natural Language', function() {
 
 		it('returns status for region Sydney', function(done) {
 			testRegionStatus('Sydney', [{
-				title: 'Sydney Region Healthy Services',
+				title: i18n.__('healthy.region.status', 'Sydney'),
 				title_link: 'http://estado.au-syd.bluemix.net',
 				color: UP_COLOR,
-				text: '175 healthy services.'
+				text: i18n.__('healthy.services', 175 + '')
 			}, {
-				title: 'Sydney Region Service Outages',
+				title: i18n.__('unhealthy.region.status', 'Sydney'),
 				title_link: 'http://estado.au-syd.bluemix.net',
 				color: DOWN_COLOR,
 				text: '- www\n- MobileApplicationContentManager [Basic]'
 			}], done);
+		});
+
+		it('should send event for missing region parameter', function(done) {
+			room.robot.on('ibmcloud.formatter', function(event) {
+				expect(event.message).to.be.a('string');
+				expect(event.message).to.eql(i18n.__('cognitive.parse.problem.region'));
+				done();
+			});
+			var res = { message: {text: 'Show me the region status', user: {id: 'anId'}}, response: room };
+			room.robot.emit('ibmcloud.region.status', res, {});
 		});
 	});
 
@@ -133,7 +169,7 @@ describe('Test cloud status via Natural Language', function() {
 
 		it('returns status for service www on region US South', function(done) {
 			testServiceStatus('US South', 'www', [{
-				title: 'www in US South Region is up',
+				title: i18n.__('service.region.status', 'www', 'US South', 'up'),
 				title_link: 'http://estado.ng.bluemix.net',
 				color: UP_COLOR
 			}], done);
@@ -141,7 +177,7 @@ describe('Test cloud status via Natural Language', function() {
 
 		it('returns status for service otc-pipeline-ui on region US South', function(done) {
 			testServiceStatus('US South', 'otc-pipeline-ui', [{
-				title: 'otc-pipeline-ui in US South Region is down',
+				title: i18n.__('service.region.status', 'otc-pipeline-ui', 'US South', 'down'),
 				title_link: 'http://estado.ng.bluemix.net',
 				color: DOWN_COLOR
 			}], done);
@@ -149,7 +185,7 @@ describe('Test cloud status via Natural Language', function() {
 
 		it('returns status for service Object-Storage-Healthcheck on region United Kingdom', function(done) {
 			testServiceStatus('United Kingdom', 'Object-Storage-Healthcheck', [{
-				title: 'Object-Storage-Healthcheck in United Kingdom Region is up',
+				title: i18n.__('service.region.status', 'Object-Storage-Healthcheck', 'United Kingdom', 'up'),
 				title_link: 'http://estado.eu-gb.bluemix.net',
 				color: UP_COLOR
 			}], done);
@@ -157,7 +193,7 @@ describe('Test cloud status via Natural Language', function() {
 
 		it('returns status for service MobileApplicationContentManager [Basic] on region United Kingdom', function(done) {
 			testServiceStatus('United Kingdom', 'MobileApplicationContentManager [Basic]', [{
-				title: 'MobileApplicationContentManager [Basic] in United Kingdom Region is down',
+				title: i18n.__('service.region.status', 'MobileApplicationContentManager [Basic]', 'United Kingdom', 'down'),
 				title_link: 'http://estado.eu-gb.bluemix.net',
 				color: DOWN_COLOR
 			}], done);
@@ -165,7 +201,7 @@ describe('Test cloud status via Natural Language', function() {
 
 		it('returns status for service APIConnect [Essentials] on region Sydney', function(done) {
 			testServiceStatus('Sydney', 'APIConnect [Essentials]', [{
-				title: 'APIConnect [Essentials] in Sydney Region is up',
+				title: i18n.__('service.region.status', 'APIConnect [Essentials]', 'Sydney', 'up'),
 				title_link: 'http://estado.au-syd.bluemix.net',
 				color: UP_COLOR
 			}], done);
@@ -173,20 +209,34 @@ describe('Test cloud status via Natural Language', function() {
 
 		it('returns status for service www on region Sydney', function(done) {
 			testServiceStatus('Sydney', 'www', [{
-				title: 'www in Sydney Region is down',
+				title: i18n.__('service.region.status', 'www', 'Sydney', 'down'),
 				title_link: 'http://estado.au-syd.bluemix.net',
 				color: DOWN_COLOR
 			}], done);
 		});
+
+		it('should send event for missing region parameter', function(done) {
+			room.robot.on('ibmcloud.formatter', function(event) {
+				expect(event.message).to.be.a('string');
+				expect(event.message).to.eql(i18n.__('cognitive.parse.problem.service'));
+				done();
+			});
+			var res = { message: {text: 'Please obtain the status in region US South', user: {id: 'anId'}}, response: room };
+			room.robot.emit('ibmcloud.service.status', res, {region: 'US South'});
+		});
+
+		it('should send event for missing service parameter', function(done) {
+			room.robot.on('ibmcloud.formatter', function(event) {
+				expect(event.message).to.be.a('string');
+				expect(event.message).to.eql(i18n.__('cognitive.parse.problem.region'));
+				done();
+			});
+			var res = { message: {text: 'Please obtain the status of service www', user: {id: 'anId'}}, response: room };
+			room.robot.emit('ibmcloud.service.status', res, {service: 'www'});
+		});
 	});
 
 	context('Monitoring service', function() {
-
-		before(function() {
-			process.env.NOTIFICATION_PERIOD_IN_MS = 1000;
-			process.env.NOTIFICATION_TIMEOUT_VALUE = 2000;
-			process.env.NOTIFICATION_TIMEOUT_LABEL = '2 seconds';
-		});
 
 		var testMonitoringServiceStatus = function(region, service, targetStatus, expectedFirstReplyAttachments, expectedSecondReplyAttachments, statusChange, done) {
 			var regionCode = REGIONS[region];
@@ -213,6 +263,9 @@ describe('Test cloud status via Natural Language', function() {
 				try {
 					if (count === 1) {
 						expect(event.attachments).to.deep.equal(expectedFirstReplyAttachments);
+					}
+					else if (count === 2) {
+						expect(event.attachments).to.deep.equal(expectedSecondReplyAttachments);
 						done();
 					}
 				}
@@ -228,12 +281,12 @@ describe('Test cloud status via Natural Language', function() {
 			this.timeout(5000);
 			testMonitoringServiceStatus('US South', 'otc-pipeline-ui', 'UP', [{
 				color: UP_COLOR,
-				text: 'otc-pipeline-ui in US South with UP status.',
-				title: 'Service monitoring started'
+				text: i18n.__('monitoring.status', 'otc-pipeline-ui', 'US South', 'UP'),
+				title: i18n.__('monitoring.started')
 			}], [{
 				color: undefined,
-				text: 'The status of service otc-pipeline-ui in region US South is still not UP after 2 seconds (current value: DOWN), Stopping monitor now.',
-				title: 'otc-pipeline-ui in US South Region',
+				text: i18n.__('service.monitoring.status', 'otc-pipeline-ui', 'US South', 'UP', '2 seconds', 'DOWN'),
+				title: i18n.__('service.in.region', 'otc-pipeline-ui', 'US South'),
 				title_link: 'http://estado.ng.bluemix.net'
 			}], false, done);
 		});
@@ -242,12 +295,12 @@ describe('Test cloud status via Natural Language', function() {
 			this.timeout(5000);
 			testMonitoringServiceStatus('US South', 'otc-pipeline-ui', 'UP', [{
 				color: UP_COLOR,
-				text: 'otc-pipeline-ui in US South with UP status.',
-				title: 'Service monitoring started'
+				text: i18n.__('monitoring.status', 'otc-pipeline-ui', 'US South', 'UP'),
+				title: i18n.__('monitoring.started')
 			}], [{
 				color: UP_COLOR,
-				text: 'Service is UP.',
-				title: 'otc-pipeline-ui in US South Region',
+				text: i18n.__('service.status', 'UP'),
+				title: i18n.__('service.in.region', 'otc-pipeline-ui', 'US South'),
 				title_link: 'http://estado.ng.bluemix.net'
 			}], true, done);
 		});
@@ -256,12 +309,12 @@ describe('Test cloud status via Natural Language', function() {
 			this.timeout(5000);
 			testMonitoringServiceStatus('United Kingdom', 'MobileApplicationContentManager [Basic]', 'UP', [{
 				color: UP_COLOR,
-				text: 'MobileApplicationContentManager [Basic] in United Kingdom with UP status.',
-				title: 'Service monitoring started'
+				text: i18n.__('monitoring.status', 'MobileApplicationContentManager [Basic]', 'United Kingdom', 'UP'),
+				title: i18n.__('monitoring.started')
 			}], [{
 				color: undefined,
-				text: 'The status of service MobileApplicationContentManager [Basic] in region United Kingdom is still not UP after 2 seconds (current value: DOWN), Stopping monitor now.',
-				title: 'MobileApplicationContentManager [Basic] in United Kingdom Region',
+				text: i18n.__('service.monitoring.status', 'MobileApplicationContentManager [Basic]', 'United Kingdom', 'UP', '2 seconds', 'DOWN'),
+				title: i18n.__('service.in.region', 'MobileApplicationContentManager [Basic]', 'United Kingdom'),
 				title_link: 'http://estado.eu-gb.bluemix.net'
 			}], false, done);
 		});
@@ -270,12 +323,12 @@ describe('Test cloud status via Natural Language', function() {
 			this.timeout(5000);
 			testMonitoringServiceStatus('United Kingdom', 'MobileApplicationContentManager [Basic]', 'UP', [{
 				color: UP_COLOR,
-				text: 'MobileApplicationContentManager [Basic] in United Kingdom with UP status.',
-				title: 'Service monitoring started'
+				text: i18n.__('monitoring.status', 'MobileApplicationContentManager [Basic]', 'United Kingdom', 'UP'),
+				title: i18n.__('monitoring.started')
 			}], [{
 				color: UP_COLOR,
-				text: 'Service is UP.',
-				title: 'MobileApplicationContentManager [Basic] in United Kingdom Region',
+				text: i18n.__('service.status', 'UP'),
+				title: i18n.__('service.in.region', 'MobileApplicationContentManager [Basic]', 'United Kingdom'),
 				title_link: 'http://estado.eu-gb.bluemix.net'
 			}], true, done);
 		});
@@ -284,12 +337,12 @@ describe('Test cloud status via Natural Language', function() {
 			this.timeout(5000);
 			testMonitoringServiceStatus('Sydney', 'www', 'UP', [{
 				color: UP_COLOR,
-				text: 'www in Sydney with UP status.',
-				title: 'Service monitoring started'
+				text: i18n.__('monitoring.status', 'www', 'Sydney', 'UP'),
+				title: i18n.__('monitoring.started')
 			}], [{
 				color: undefined,
-				text: 'The status of service www in region Sydney is still not UP after 2 seconds (current value: DOWN), Stopping monitor now.',
-				title: 'www in Sydney Region',
+				text: i18n.__('service.monitoring.status', 'www', 'Sydney', 'UP', '2 seconds', 'DOWN'),
+				title: i18n.__('service.in.region', 'www', 'Sydney'),
 				title_link: 'http://estado.au-syd.bluemix.net'
 			}], false, done);
 		});
@@ -298,14 +351,132 @@ describe('Test cloud status via Natural Language', function() {
 			this.timeout(5000);
 			testMonitoringServiceStatus('Sydney', 'www', 'UP', [{
 				color: UP_COLOR,
-				text: 'www in Sydney with UP status.',
-				title: 'Service monitoring started'
+				text: i18n.__('monitoring.status', 'www', 'Sydney', 'UP'),
+				title: i18n.__('monitoring.started')
 			}], [{
 				color: UP_COLOR,
-				text: 'Service is UP.',
-				title: 'www in Sydney Region',
+				text: i18n.__('service.status', 'UP'),
+				title: i18n.__('service.in.region', 'www', 'Sydney'),
 				title_link: 'http://estado.au-syd.bluemix.net'
 			}], true, done);
+		});
+
+		it('should send event for missing region parameter', function(done) {
+			room.robot.on('ibmcloud.formatter', function(event) {
+				expect(event.message).to.be.a('string');
+				expect(event.message).to.eql(i18n.__('cognitive.parse.problem.region'));
+				done();
+			});
+			var res = { message: {text: 'Notify me when the service health changes www', user: {id: 'anId'}}, response: room };
+			room.robot.emit('ibmcloud.service.monitor', res, {service: 'www', status: 'up'});
+		});
+
+		it('should send event for missing service parameter', function(done) {
+			room.robot.on('ibmcloud.formatter', function(event) {
+				expect(event.message).to.be.a('string');
+				expect(event.message).to.eql(i18n.__('cognitive.parse.problem.service'));
+				done();
+			});
+			var res = { message: {text: 'Notify me when the service health changes in region US South', user: {id: 'anId'}}, response: room };
+			room.robot.emit('ibmcloud.service.monitor', res, {region: 'US South', status: 'up'});
+		});
+
+		it('should send event for missing status parameter', function(done) {
+			room.robot.on('ibmcloud.formatter', function(event) {
+				expect(event.message).to.be.a('string');
+				expect(event.message).to.eql(i18n.__('cognitive.parse.problem.status'));
+				done();
+			});
+			var res = { message: {text: 'Notify me when the service health changes www in region US South', user: {id: 'anId'}}, response: room };
+			room.robot.emit('ibmcloud.service.monitor', res, {region: 'US South', service: 'www'});
+		});
+	});
+
+	context('Getting space status', function() {
+
+		var testSpaceStatus = function(region, expectedReplyAttachments, useUpdated, done) {
+			var regionCode = REGIONS[region];
+			nock('http://estado.' + regionCode + '.bluemix.net')
+				.get('/')
+				.reply(200, mockHtml[regionCode + (useUpdated ? '-updated' : '')]);
+			room.robot.on('ibmcloud.formatter', function(event) {
+				try {
+					expect(event.attachments).to.deep.equal(expectedReplyAttachments);
+					done();
+				}
+				catch (err) {
+					done(err);
+				}
+			});
+
+			var res = { message: {text: 'Please obtain the status of the services in the current space', user: {id: 'anId'}}, response: room };
+			room.robot.emit('ibmcloud.space.status', res, {});
+		};
+
+		it('returns status for current space (mixed statuses)', function(done) {
+			testSpaceStatus('US South', [{
+				title: i18n.__('healthy.space.status', 'testSpace'),
+				title_link: 'http://estado.ng.bluemix.net',
+				color: UP_COLOR,
+				text: i18n.__('healthy.services', 2 + '')
+			}, {
+				title: i18n.__('unhealthy.space.status', 'testSpace'),
+				title_link: 'http://estado.ng.bluemix.net',
+				color: DOWN_COLOR,
+				text: '- messageconnect [experimental]'
+			}], false, done);
+		});
+
+		it('returns status for current space (all up)', function(done) {
+			testSpaceStatus('US South', [{
+				title: i18n.__('healthy.space.status', 'testSpace'),
+				title_link: 'http://estado.ng.bluemix.net',
+				color: UP_COLOR,
+				fields: [{
+					title: i18n.__('services.doing.well'),
+					value: i18n.__('all.services.up', 3 + '')
+				}]
+			}], true, done);
+		});
+
+	});
+
+	context('Monitoring space', function() {
+
+		it('should enable and then disable monitoring of services in the current space', function(done) {
+			let expectedFirstReplyAttachments = [{
+				title: i18n.__('monitoring.space.started', 'testSpace'),
+				color: UP_COLOR
+			}];
+			let expectedSecondReplyAttachments = [{
+				title: i18n.__('monitoring.space.stopped', 'testSpace'),
+				color: UP_COLOR
+			}];
+			var count = 0;
+			room.robot.on('ibmcloud.formatter', function(event) {
+				count++;
+				if (count === 1) {
+					expect(event.attachments).to.deep.equal(expectedFirstReplyAttachments);
+					var res2 = { message: {text: 'Stop notifying me when the service health changes in region US South', user: {id: 'anId'}}, response: room };
+					room.robot.emit('ibmcloud.space.monitor', res2, {spacestatus: 'clear'});
+				}
+				else if (count === 2) {
+					expect(event.attachments).to.deep.equal(expectedSecondReplyAttachments);
+					done();
+				}
+			});
+			var res = { message: {text: 'Notify me when the service health changes in region US South', user: {id: 'anId'}}, response: room };
+			room.robot.emit('ibmcloud.space.monitor', res, {spacestatus: 'any'});
+		});
+
+		it('should send event for missing spacestatus parameter', function(done) {
+			room.robot.on('ibmcloud.formatter', function(event) {
+				expect(event.message).to.be.a('string');
+				expect(event.message).to.eql(i18n.__('cognitive.parse.problem.spacestatus'));
+				done();
+			});
+			var res = { message: {text: 'Notify me when services in the current space change status', user: {id: 'anId'}}, response: room };
+			room.robot.emit('ibmcloud.space.monitor', res, {});
 		});
 	});
 

--- a/test/ibmcloud.status.test.js
+++ b/test/ibmcloud.status.test.js
@@ -5,6 +5,24 @@ var path = require('path');
 var Helper = require('hubot-test-helper');
 var expect = require('chai').expect;
 var nock = require('nock');
+const mockUtils = require('./mock.utils.cf.js');
+
+
+// --------------------------------------------------------------
+// i18n (internationalization)
+// It will read from a peer messages.json file.  Later, these
+// messages can be referenced throughout the module.
+// --------------------------------------------------------------
+var i18n = new (require('i18n-2'))({
+	locales: ['en'],
+	extension: '.json',
+	directory: __dirname + '/../src/locales',
+	defaultLocale: 'en',
+	// Prevent messages file from being overwritten in error conditions (like poor JSON).
+	updateFiles: false
+});
+// At some point we need to toggle this setting based on some user input.
+i18n.setLocale('en');
 
 // No cache for the tests
 process.env.CACHE_TIMEOUT = '-1';
@@ -29,9 +47,54 @@ var mockHtml = {
 
 var helper = new Helper(path.join(__dirname, '../src/scripts/ibmcloud.status.js'));
 
+describe('Load modules through index', function() {
+
+	var room;
+	let cf;
+
+	before(function() {
+		mockUtils.setupMockery();
+		// initialize cf, hubot-test-helper doesn't test Middleware
+		cf = require('hubot-cf-convenience');
+		return cf.promise.then();
+	});
+
+	beforeEach(function() {
+		room = helper.createRoom();
+		nock.disableNetConnect();
+		// Force all emits into a reply.
+		room.robot.on('ibmcloud.formatter', function(event) {
+			if (event.message) {
+				event.response.reply(event.message);
+			}
+			else {
+				event.response.send({attachments: event.attachments});
+			}
+		});
+	});
+
+	afterEach(function() {
+		room.destroy();
+	});
+
+	context('load index`', function() {
+		it('should load without problems', function() {
+			require('../index')(room.robot);
+		});
+	});
+});
+
 describe('Test cloud status via Reg Ex', function() {
 
 	var room;
+	let cf;
+
+	before(function() {
+		mockUtils.setupMockery();
+		// initialize cf, hubot-test-helper doesn't test Middleware
+		cf = require('hubot-cf-convenience');
+		return cf.promise.then();
+	});
 
 	beforeEach(function() {
 		room = helper.createRoom();
@@ -72,12 +135,12 @@ describe('Test cloud status via Reg Ex', function() {
 
 		it('returns status for region US South', function(done) {
 			testRegionStatus('US South', [{
-				title: 'US South Region Healthy Services',
+				title: i18n.__('healthy.region.status', 'US South'),
 				title_link: 'http://estado.ng.bluemix.net',
 				color: UP_COLOR,
-				text: '295 healthy services.'
+				text: i18n.__('healthy.services', 295 + '')
 			}, {
-				title: 'US South Region Service Outages',
+				title: i18n.__('unhealthy.region.status', 'US South'),
 				title_link: 'http://estado.ng.bluemix.net',
 				color: DOWN_COLOR,
 				text: '- otc-pipeline-ui\n- messageconnect [experimental]\n- MobileApplicationContentManager [Basic]'
@@ -86,12 +149,12 @@ describe('Test cloud status via Reg Ex', function() {
 
 		it('returns status for region United Kingdom', function(done) {
 			testRegionStatus('United Kingdom', [{
-				title: 'United Kingdom Region Healthy Services',
+				title: i18n.__('healthy.region.status', 'United Kingdom'),
 				title_link: 'http://estado.eu-gb.bluemix.net',
 				color: UP_COLOR,
-				text: '236 healthy services.'
+				text: i18n.__('healthy.services', 236 + '')
 			}, {
-				title: 'United Kingdom Region Service Outages',
+				title: i18n.__('unhealthy.region.status', 'United Kingdom'),
 				title_link: 'http://estado.eu-gb.bluemix.net',
 				color: DOWN_COLOR,
 				text: '- MobileApplicationContentManager [Basic]'
@@ -100,12 +163,12 @@ describe('Test cloud status via Reg Ex', function() {
 
 		it('returns status for region Sydney', function(done) {
 			testRegionStatus('Sydney', [{
-				title: 'Sydney Region Healthy Services',
+				title: i18n.__('healthy.region.status', 'Sydney'),
 				title_link: 'http://estado.au-syd.bluemix.net',
 				color: UP_COLOR,
-				text: '175 healthy services.'
+				text: i18n.__('healthy.services', 175 + '')
 			}, {
-				title: 'Sydney Region Service Outages',
+				title: i18n.__('unhealthy.region.status', 'Sydney'),
 				title_link: 'http://estado.au-syd.bluemix.net',
 				color: DOWN_COLOR,
 				text: '- www\n- MobileApplicationContentManager [Basic]'
@@ -136,7 +199,7 @@ describe('Test cloud status via Reg Ex', function() {
 
 		it('returns status for service www on region US South', function(done) {
 			testServiceStatus('US South', 'www', [{
-				title: 'www in US South Region is up',
+				title: i18n.__('service.region.status', 'www', 'US South', 'up'),
 				title_link: 'http://estado.ng.bluemix.net',
 				color: UP_COLOR
 			}], done);
@@ -144,7 +207,7 @@ describe('Test cloud status via Reg Ex', function() {
 
 		it('returns status for service otc-pipeline-ui on region US South', function(done) {
 			testServiceStatus('US South', 'otc-pipeline-ui', [{
-				title: 'otc-pipeline-ui in US South Region is down',
+				title: i18n.__('service.region.status', 'otc-pipeline-ui', 'US South', 'down'),
 				title_link: 'http://estado.ng.bluemix.net',
 				color: DOWN_COLOR
 			}], done);
@@ -152,7 +215,7 @@ describe('Test cloud status via Reg Ex', function() {
 
 		it('returns status for service Object-Storage-Healthcheck on region United Kingdom', function(done) {
 			testServiceStatus('United Kingdom', 'Object-Storage-Healthcheck', [{
-				title: 'Object-Storage-Healthcheck in United Kingdom Region is up',
+				title: i18n.__('service.region.status', 'Object-Storage-Healthcheck', 'United Kingdom', 'up'),
 				title_link: 'http://estado.eu-gb.bluemix.net',
 				color: UP_COLOR
 			}], done);
@@ -160,7 +223,7 @@ describe('Test cloud status via Reg Ex', function() {
 
 		it('returns status for service MobileApplicationContentManager [Basic] on region United Kingdom', function(done) {
 			testServiceStatus('United Kingdom', 'MobileApplicationContentManager [Basic]', [{
-				title: 'MobileApplicationContentManager [Basic] in United Kingdom Region is down',
+				title: i18n.__('service.region.status', 'MobileApplicationContentManager [Basic]', 'United Kingdom', 'down'),
 				title_link: 'http://estado.eu-gb.bluemix.net',
 				color: DOWN_COLOR
 			}], done);
@@ -168,7 +231,7 @@ describe('Test cloud status via Reg Ex', function() {
 
 		it('returns status for service APIConnect [Essentials] on region Sydney', function(done) {
 			testServiceStatus('Sydney', 'APIConnect [Essentials]', [{
-				title: 'APIConnect [Essentials] in Sydney Region is up',
+				title: i18n.__('service.region.status', 'APIConnect [Essentials]', 'Sydney', 'up'),
 				title_link: 'http://estado.au-syd.bluemix.net',
 				color: UP_COLOR
 			}], done);
@@ -176,7 +239,7 @@ describe('Test cloud status via Reg Ex', function() {
 
 		it('returns status for service www on region Sydney', function(done) {
 			testServiceStatus('Sydney', 'www', [{
-				title: 'www in Sydney Region is down',
+				title: i18n.__('service.region.status', 'www', 'Sydney', 'down'),
 				title_link: 'http://estado.au-syd.bluemix.net',
 				color: DOWN_COLOR
 			}], done);
@@ -184,12 +247,6 @@ describe('Test cloud status via Reg Ex', function() {
 	});
 
 	context('Monitoring service', function() {
-
-		before(function() {
-			process.env.NOTIFICATION_PERIOD_IN_MS = 1000;
-			process.env.NOTIFICATION_TIMEOUT_VALUE = 2000;
-			process.env.NOTIFICATION_TIMEOUT_LABEL = '2 seconds';
-		});
 
 		var testMonitoringServiceStatus = function(region, service, targetStatus, expectedFirstReplyAttachments, expectedSecondReplyAttachments, statusChange, done) {
 			var regionCode = REGIONS[region];
@@ -233,12 +290,12 @@ describe('Test cloud status via Reg Ex', function() {
 			this.timeout(5000);
 			testMonitoringServiceStatus('US South', 'otc-pipeline-ui', 'UP', [{
 				color: UP_COLOR,
-				text: 'otc-pipeline-ui in US South with UP status.',
-				title: 'Service monitoring started'
+				text: i18n.__('monitoring.status', 'otc-pipeline-ui', 'US South', 'UP'),
+				title: i18n.__('monitoring.started')
 			}], [{
 				color: undefined,
-				text: 'The status of service otc-pipeline-ui in region US South is still not UP after 2 seconds (current value: DOWN), Stopping monitor now.',
-				title: 'otc-pipeline-ui in US South Region',
+				text: i18n.__('service.monitoring.status', 'otc-pipeline-ui', 'US South', 'UP', '2 seconds', 'DOWN'),
+				title: i18n.__('service.in.region', 'otc-pipeline-ui', 'US South'),
 				title_link: 'http://estado.ng.bluemix.net'
 			}], false, done);
 		});
@@ -247,12 +304,12 @@ describe('Test cloud status via Reg Ex', function() {
 			this.timeout(5000);
 			testMonitoringServiceStatus('US South', 'otc-pipeline-ui', 'UP', [{
 				color: UP_COLOR,
-				text: 'otc-pipeline-ui in US South with UP status.',
-				title: 'Service monitoring started'
+				text: i18n.__('monitoring.status', 'otc-pipeline-ui', 'US South', 'UP'),
+				title: i18n.__('monitoring.started')
 			}], [{
 				color: UP_COLOR,
-				text: 'Service is UP.',
-				title: 'otc-pipeline-ui in US South Region',
+				text: i18n.__('service.status', 'UP'),
+				title: i18n.__('service.in.region', 'otc-pipeline-ui', 'US South'),
 				title_link: 'http://estado.ng.bluemix.net'
 			}], true, done);
 		});
@@ -261,12 +318,12 @@ describe('Test cloud status via Reg Ex', function() {
 			this.timeout(5000);
 			testMonitoringServiceStatus('United Kingdom', 'MobileApplicationContentManager [Basic]', 'UP', [{
 				color: UP_COLOR,
-				text: 'MobileApplicationContentManager [Basic] in United Kingdom with UP status.',
-				title: 'Service monitoring started'
+				text: i18n.__('monitoring.status', 'MobileApplicationContentManager [Basic]', 'United Kingdom', 'UP'),
+				title: i18n.__('monitoring.started')
 			}], [{
 				color: undefined,
-				text: 'The status of service MobileApplicationContentManager [Basic] in region United Kingdom is still not UP after 2 seconds (current value: DOWN), Stopping monitor now.',
-				title: 'MobileApplicationContentManager [Basic] in United Kingdom Region',
+				text: i18n.__('service.monitoring.status', 'MobileApplicationContentManager [Basic]', 'United Kingdom', 'UP', '2 seconds', 'DOWN'),
+				title: i18n.__('service.in.region', 'MobileApplicationContentManager [Basic]', 'United Kingdom'),
 				title_link: 'http://estado.eu-gb.bluemix.net'
 			}], false, done);
 		});
@@ -275,12 +332,12 @@ describe('Test cloud status via Reg Ex', function() {
 			this.timeout(5000);
 			testMonitoringServiceStatus('United Kingdom', 'MobileApplicationContentManager [Basic]', 'UP', [{
 				color: UP_COLOR,
-				text: 'MobileApplicationContentManager [Basic] in United Kingdom with UP status.',
-				title: 'Service monitoring started'
+				text: i18n.__('monitoring.status', 'MobileApplicationContentManager [Basic]', 'United Kingdom', 'UP'),
+				title: i18n.__('monitoring.started')
 			}], [{
 				color: UP_COLOR,
-				text: 'Service is UP.',
-				title: 'MobileApplicationContentManager [Basic] in United Kingdom Region',
+				text: i18n.__('service.status', 'UP'),
+				title: i18n.__('service.in.region', 'MobileApplicationContentManager [Basic]', 'United Kingdom'),
 				title_link: 'http://estado.eu-gb.bluemix.net'
 			}], true, done);
 		});
@@ -289,12 +346,12 @@ describe('Test cloud status via Reg Ex', function() {
 			this.timeout(5000);
 			testMonitoringServiceStatus('Sydney', 'www', 'UP', [{
 				color: UP_COLOR,
-				text: 'www in Sydney with UP status.',
-				title: 'Service monitoring started'
+				text: i18n.__('monitoring.status', 'www', 'Sydney', 'UP'),
+				title: i18n.__('monitoring.started')
 			}], [{
 				color: undefined,
-				text: 'The status of service www in region Sydney is still not UP after 2 seconds (current value: DOWN), Stopping monitor now.',
-				title: 'www in Sydney Region',
+				text: i18n.__('service.monitoring.status', 'www', 'Sydney', 'UP', '2 seconds', 'DOWN'),
+				title: i18n.__('service.in.region', 'www', 'Sydney'),
 				title_link: 'http://estado.au-syd.bluemix.net'
 			}], false, done);
 		});
@@ -303,13 +360,266 @@ describe('Test cloud status via Reg Ex', function() {
 			this.timeout(5000);
 			testMonitoringServiceStatus('Sydney', 'www', 'UP', [{
 				color: UP_COLOR,
-				text: 'www in Sydney with UP status.',
-				title: 'Service monitoring started'
+				text: i18n.__('monitoring.status', 'www', 'Sydney', 'UP'),
+				title: i18n.__('monitoring.started')
 			}], [{
 				color: UP_COLOR,
-				text: 'Service is UP.',
-				title: 'www in Sydney Region',
+				text: i18n.__('service.status', 'UP'),
+				title: i18n.__('service.in.region', 'www', 'Sydney'),
 				title_link: 'http://estado.au-syd.bluemix.net'
+			}], true, done);
+		});
+	});
+
+	context('Monitoring service with any/clear', function() {
+
+		var testMonitoringServiceStatusAny = function(region, service, expectedFirstReplyAttachments, expectedSecondReplyAttachments, expectedThirdReplyAttachments, expectedFourthReplyAttachments, statusChange, done) {
+			var regionCode = REGIONS[region];
+			if (statusChange) {
+				// First status
+				nock('http://estado.' + regionCode + '.bluemix.net')
+					.get('/')
+					.reply(200, mockHtml[regionCode]);
+				// Second status (same)
+				nock('http://estado.' + regionCode + '.bluemix.net')
+					.get('/')
+					.reply(200, mockHtml[regionCode]);
+				// Third status (updated)
+				nock('http://estado.' + regionCode + '.bluemix.net')
+					.get('/')
+					.reply(200, mockHtml[regionCode + '-updated']);
+				// Fourth status (back to original)
+				nock('http://estado.' + regionCode + '.bluemix.net')
+					.get('/')
+					.reply(200, mockHtml[regionCode]);
+			}
+			else {
+				// Same status four times
+				nock('http://estado.' + regionCode + '.bluemix.net')
+					.get('/')
+					.times(4)
+					.reply(200, mockHtml[regionCode]);
+			}
+			var count = 0;
+			room.robot.on('ibmcloud.formatter', function(event) {
+				count++;
+				try {
+					if (count === 1) {
+						expect(event.attachments).to.deep.equal(expectedFirstReplyAttachments);
+					}
+					else if (count === 2) {
+						expect(event.attachments).to.deep.equal(expectedSecondReplyAttachments);
+						if (!statusChange) {
+							done();
+						}
+					}
+					else if (count === 3) {
+						if (statusChange) {
+							expect(event.attachments).to.deep.equal(expectedThirdReplyAttachments);
+						}
+						else {
+							done(new Error('Unexpected third attachments: ' + event.attachments));
+						}
+					}
+					else if (count === 4) {
+						if (statusChange) {
+							expect(event.attachments).to.deep.equal(expectedFourthReplyAttachments);
+							done();
+						}
+						else {
+							done(new Error('Unexpected fourth attachments: ' + event.attachments));
+						}
+					}
+				}
+				catch (err) {
+					done(err);
+				}
+			});
+			room.user.say('user1', '@hubot ibmcloud status monitor ' + region + ' any ' + service).then(setTimeout(function() {
+				room.user.say('user1', '@hubot ibmcloud status monitor ' + region + ' clear ' + service);
+			}, 4500));
+		};
+
+		it('monitor status for messageconnect [experimental] in US South Region (no status change)', function(done) {
+			this.timeout(5000);
+			testMonitoringServiceStatusAny('US South', 'messageconnect [experimental]', [{
+				color: UP_COLOR,
+				text: i18n.__('monitoring.status.any', 'messageconnect [experimental]', 'US South'),
+				title: i18n.__('monitoring.started')
+			}], [{
+				title: i18n.__('monitoring.stopped', 'messageconnect [experimental]', 'US South'),
+				color: UP_COLOR
+			}], [], [], false, done);
+		});
+
+		it('monitor status for messageconnect [experimental] in US South Region (status change)', function(done) {
+			this.timeout(5000);
+			testMonitoringServiceStatusAny('US South', 'messageconnect [experimental]', [{
+				color: UP_COLOR,
+				text: i18n.__('monitoring.status.any', 'messageconnect [experimental]', 'US South'),
+				title: i18n.__('monitoring.started')
+			}], [{
+				title: i18n.__('service.in.region', 'messageconnect [experimental]', 'US South'),
+				title_link: 'http://estado.ng.bluemix.net',
+				text: i18n.__('service.status', 'UP'),
+				color: UP_COLOR
+			}], [{
+				title: i18n.__('service.in.region', 'messageconnect [experimental]', 'US South'),
+				title_link: 'http://estado.ng.bluemix.net',
+				text: i18n.__('service.status', 'DOWN'),
+				color: DOWN_COLOR
+			}], [{
+				title: i18n.__('monitoring.stopped', 'messageconnect [experimental]', 'US South'),
+				color: UP_COLOR
+			}], true, done);
+		});
+	});
+
+	context('Getting space status', function() {
+
+		var testSpaceStatus = function(region, expectedReplyAttachments, useUpdated, done) {
+			var regionCode = REGIONS[region];
+			nock('http://estado.' + regionCode + '.bluemix.net')
+				.get('/')
+				.reply(200, mockHtml[regionCode + (useUpdated ? '-updated' : '')]);
+			room.robot.on('ibmcloud.formatter', function(event) {
+				try {
+					expect(event.attachments).to.deep.equal(expectedReplyAttachments);
+					done();
+				}
+				catch (err) {
+					done(err);
+				}
+			});
+			room.user.say('user1', '@hubot ibmcloud status space').then();
+		};
+
+		it('returns status for current space (mixed statuses)', function(done) {
+			testSpaceStatus('US South', [{
+				title: i18n.__('healthy.space.status', 'testSpace'),
+				title_link: 'http://estado.ng.bluemix.net',
+				color: UP_COLOR,
+				text: i18n.__('healthy.services', 2 + '')
+			}, {
+				title: i18n.__('unhealthy.space.status', 'testSpace'),
+				title_link: 'http://estado.ng.bluemix.net',
+				color: DOWN_COLOR,
+				text: '- messageconnect [experimental]'
+			}], false, done);
+		});
+
+		it('returns status for current space (all up)', function(done) {
+			testSpaceStatus('US South', [{
+				title: i18n.__('healthy.space.status', 'testSpace'),
+				title_link: 'http://estado.ng.bluemix.net',
+				color: UP_COLOR,
+				fields: [{
+					title: i18n.__('services.doing.well'),
+					value: i18n.__('all.services.up', 3 + '')
+				}]
+			}], true, done);
+		});
+
+	});
+
+	context('Monitoring space', function() {
+
+		var testMonitoringSpace = function(region, expectedFirstReplyAttachments, expectedSecondReplyAttachments, expectedThirdReplyAttachments, expectedFourthReplyAttachments, statusChange, done) {
+			var regionCode = REGIONS[region];
+			if (statusChange) {
+				// First status
+				nock('http://estado.' + regionCode + '.bluemix.net')
+					.get('/')
+					.reply(200, mockHtml[regionCode]);
+				// Second status (same)
+				nock('http://estado.' + regionCode + '.bluemix.net')
+					.get('/')
+					.reply(200, mockHtml[regionCode]);
+				// Third status (updated)
+				nock('http://estado.' + regionCode + '.bluemix.net')
+					.get('/')
+					.reply(200, mockHtml[regionCode + '-updated']);
+				// Fourth status (back to original)
+				nock('http://estado.' + regionCode + '.bluemix.net')
+					.get('/')
+					.reply(200, mockHtml[regionCode]);
+			}
+			else {
+				// Same status four times
+				nock('http://estado.' + regionCode + '.bluemix.net')
+					.get('/')
+					.times(4)
+					.reply(200, mockHtml[regionCode]);
+			}
+			var count = 0;
+			room.robot.on('ibmcloud.formatter', function(event) {
+				count++;
+				try {
+					if (count === 1) {
+						expect(event.attachments).to.deep.equal(expectedFirstReplyAttachments);
+					}
+					else if (count === 2) {
+						expect(event.attachments).to.deep.equal(expectedSecondReplyAttachments);
+						if (!statusChange) {
+							done();
+						}
+					}
+					else if (count === 3) {
+						if (statusChange) {
+							expect(event.attachments).to.deep.equal(expectedThirdReplyAttachments);
+						}
+						else {
+							done(new Error('Unexpected third attachments: ' + event.attachments));
+						}
+					}
+					else if (count === 4) {
+						if (statusChange) {
+							expect(event.attachments).to.deep.equal(expectedFourthReplyAttachments);
+							done();
+						}
+						else {
+							done(new Error('Unexpected fourth attachments: ' + event.attachments));
+						}
+					}
+				}
+				catch (err) {
+					done(err);
+				}
+			});
+			room.user.say('user1', '@hubot ibmcloud status monitor space any').then(setTimeout(function() {
+				room.user.say('user1', '@hubot ibmcloud status monitor space clear');
+			}, 4500));
+		};
+
+		it('monitor space (no status change)', function(done) {
+			this.timeout(7000);
+			testMonitoringSpace('US South', [{
+				color: UP_COLOR,
+				title: i18n.__('monitoring.space.started', 'testSpace')
+			}], [{
+				color: UP_COLOR,
+				title: i18n.__('monitoring.space.stopped', 'testSpace')
+			}], [], [], false, done);
+		});
+
+		it('monitor space (status change)', function(done) {
+			this.timeout(7000);
+			testMonitoringSpace('US South', [{
+				color: UP_COLOR,
+				title: i18n.__('monitoring.space.started', 'testSpace')
+			}], [{
+				title: i18n.__('service.in.space', 'messageconnect [experimental]', 'testSpace'),
+				title_link: 'http://estado.ng.bluemix.net',
+				text: i18n.__('service.status', 'UP'),
+				color: UP_COLOR
+			}], [{
+				title: i18n.__('service.in.space', 'messageconnect [experimental]', 'testSpace'),
+				title_link: 'http://estado.ng.bluemix.net',
+				text: i18n.__('service.status', 'DOWN'),
+				color: DOWN_COLOR
+			}], [{
+				color: UP_COLOR,
+				title: i18n.__('monitoring.space.stopped', 'testSpace')
 			}], true, done);
 		});
 	});
@@ -320,8 +630,13 @@ describe('Test cloud status via Reg Ex', function() {
 		});
 
 		it('should respond with help', function() {
+			let expectedHelp = `hubot ibmcloud status region [US South | United Kingdom | Sydney] - ${i18n.__('ibmcloud.status.region.help')}\n`;
+			expectedHelp += `hubot ibmcloud status service [US South | United Kingdom | Sydney] [SERVICE] - ${i18n.__('ibmcloud.status.service.help')}\n`;
+			expectedHelp += `hubot ibmcloud status monitor [US South | United Kingdom | Sydney] [UP|DOWN|ANY|CLEAR][SERVICE] - ${i18n.__('ibmcloud.status.monitor.help', '|')}\n`;
+			expectedHelp += `hubot ibmcloud status space - ${i18n.__('ibmcloud.status.space.help')}\n`;
+			expectedHelp += `hubot ibmcloud status monitor space [ANY|CLEAR] - ${i18n.__('ibmcloud.status.monitor.space.help', '|')}\n`;
 			expect(room.messages.length).to.eql(2);
-			expect(room.messages[1]).to.eql(['hubot', '@mimiron hubot ibmcloud status region [US South | United Kingdom | Sydney] - Provide status for IBM Cloud services in region.\nhubot ibmcloud status service [US South | United Kingdom | Sydney] [SERVICE] - Provide status for IBM Cloud service named [SERVICE] in region.\nhubot ibmcloud status monitor [US South | United Kingdom | Sydney] [UP|DOWN][SERVICE] - Monitor and send notifications when [SERVICE] in region goes [UP|DOWN].\n']);
+			expect(room.messages[1]).to.eql(['hubot', `@mimiron ${expectedHelp}`]);
 		});
 	});
 

--- a/test/mock.utils.cf.js
+++ b/test/mock.utils.cf.js
@@ -1,0 +1,162 @@
+/*
+  * Licensed Materials - Property of IBM
+  * (C) Copyright IBM Corp. 2016. All Rights Reserved.
+  * US Government Users Restricted Rights - Use, duplication or
+  * disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+  */
+'use strict';
+
+const nock = require('nock');
+nock.disableNetConnect();
+nock.enableNetConnect('localhost');
+
+const endpoint = 'http://my.ng.test';
+const cfVersion = 'v2';
+
+module.exports = {
+
+	setupMockery: function() {
+		let cfScope = nock(endpoint)
+			.persist();
+
+		// https://apidocs.cloudfoundry.org/236/info/get_info.html
+		cfScope.get(`/${cfVersion}/info`)
+			.reply(200, { authorization_endpoint: 'http://my.ng.test/uaa' });
+
+		// https://apidocs.cloudfoundry.org/236/organizations/list_all_organizations.html
+		cfScope.get(`/${cfVersion}/organizations`)
+			.reply(200,
+			{
+				resources: [
+					{
+						metadata: {
+							guid: 'testOrgGuid'
+						},
+						entity: {
+							name: 'testOrg'
+						}
+					}
+				]
+			});
+
+		// https://apidocs.cloudfoundry.org/236/organizations/get_organization_summary.html
+		cfScope.get(`/${cfVersion}/organizations/testOrgGuid/summary`)
+			.reply(200,
+			{
+				spaces: [
+					{
+						guid: 'testSpaceGuid',
+						name: 'testSpace',
+						app_count: 2,
+						service_count: 1,
+						mem_dev_total: 0
+					}
+				]
+			});
+
+		// https://apidocs.cloudfoundry.org/236/spaces/get_space_summary.html
+		cfScope.get(`/${cfVersion}/spaces/testSpaceGuid/summary`)
+			.reply(200,
+			{
+				apps: [
+					{
+						guid: 'testApp1Guid',
+						urls: [
+							'testApp1Url'
+						],
+						name: 'testApp1Name',
+						instances: 1,
+						running_instances: 1,
+						state: 'STARTED',
+						memory: 1024,
+						disk_quota: 1024,
+						service_names: [
+							'cloudantNoSQLDB'
+						]
+					},
+					{
+						guid: 'testApp2Guid',
+						urls: [
+							'testApp2Url'
+						],
+						name: 'testApp2Name',
+						instances: 1,
+						running_instances: 1,
+						state: 'STOPPED',
+						memory: 1024,
+						disk_quota: 1024,
+						service_names: []
+					},
+					{
+						guid: 'testApp4Guid',
+						urls: [
+							'testApp4Url'
+						],
+						name: 'testApp4Name',
+						instances: 1,
+						running_instances: 1,
+						state: 'STOPPED',
+						memory: 1024,
+						disk_quota: 1024,
+						service_names: []
+					},
+					{
+						guid: 'testAppLongLogsGuid',
+						urls: [
+							'testAppLongLogsUrl'
+						],
+						name: 'testAppLongLogsName',
+						instances: 1,
+						running_instances: 1,
+						state: 'STARTED',
+						memory: 1024,
+						disk_quota: 1024,
+						service_names: [
+							'messageconnect',
+							'Object-Storage'
+						]
+					}
+				],
+				services: [
+					{
+						guid: 'cloudantNoSQLDBGuid',
+						name: 'cloudantNoSQLDB',
+						bound_app_count: 1,
+						service_plan: {
+							service: {
+								label: 'cloudantNoSQLDB'
+							},
+							name: 'Shared'
+						}
+					},
+					{
+						guid: 'messageconnectGuid',
+						name: 'messageconnect',
+						bound_app_count: 0,
+						service_plan: {
+							service: {
+								label: 'messageconnect'
+							},
+							name: 'experimental'
+						}
+					},
+					{
+						guid: 'Object-StorageGuid',
+						name: 'Object-Storage',
+						bound_app_count: 0,
+						service_plan: {
+							service: {
+								label: 'Object-Storage'
+							},
+							name: 'standard'
+						}
+					}
+				]
+			});
+
+
+		cfScope.post('/uaa/oauth/token')
+			.reply(200, { access_token: 'mycredformockservice' });
+
+	}
+};

--- a/test/resources/estado-ng-updated.html
+++ b/test/resources/estado-ng-updated.html
@@ -688,7 +688,7 @@
 </tr>
 <tr class="danger">
 <td>messageconnect [experimental]</td>
-<td>down</td>
+<td>up</td>
 </tr>
 <tr class="active">
 <td>messagehub [standard]</td>


### PR DESCRIPTION
Added two new commands:
 `ibmcloud status space`
 `ibmcloud status monitor space [any|clear]`

Also enhanced the following command:
 `ibmcloud status monitor [region] [up|down|any|clear] [service]`
by adding the `any` and `clear` options.  The `any` allows the monitor to persist.  It reports any transition from up->down or down->up until the monitor is removed.  It is removed by using the `clear` option.
